### PR TITLE
Default unknown genre to genre ID 12 "other"

### DIFF
--- a/abcde
+++ b/abcde
@@ -906,7 +906,7 @@ do_getgenreid () {
 		"jpop")                  id=146 ;;
 		"synthpop")              id=147 ;;
 		"rock/pop"|"rock / pop") id=148 ;;
-		*)                       id=255 ;;
+		*)                       id=12  ;;
 	esac
 echo ${id}
 return 0


### PR DESCRIPTION
If no genre is found, abcde will default the genre tag to 255, but according to (https://en.wikipedia.org/wiki/List_of_ID3v1_genres), there is no entry for 255.