### PR TITLE
Adjust leadout when reading embedded flac cuesheet

### DIFF
--- a/abcde
+++ b/abcde
@@ -2230,6 +2230,7 @@ do_discid ()
 
 							LEADOUT=$(( $(echo "$CUESHEET" | grep lead-out | get_last) * 75 / 44100 ))
 							LEADIN=$(( $(echo "$CUESHEET" | grep lead-in | get_last) * 75 / 44100 ))
+							LEADOUT=$((LEADOUT - $(set - $OFFSETS; echo $1)))
 							makeids
 						;;
 						*)


### PR DESCRIPTION
Tl;DR: Makes it possible to do properly do musicbrainz lookups on  flacs with embedded cues that have non-standard pregaps

Very slightly longer description:

1. Without this change, if you embed a flac cuesheet ripped with `abcde.mkcue` and `--wholedisk`  the musicbrainz lookup will fail for all discs.
2. Regardless of this change, if you don't use `--wholedisk` then any disc with a pregap other than 150 frames will also fail the musicbrainz lookup
3. This change fixes the MB lookup for all disks with `--wholedisk` (including 3 discs I tried with non-standard pregaps)

More details:

- The Musicbrainz lookup code adds the pregap to the leadout, so to get proper results when looking up embedded flac cuesheets generated with `--wholedisk` we need to subtract the pregap from the leadout.
- I tested on several disks ripped without `--wholedisk` and confirmed that this did not affect the musicbrainz ID generated, so this change should affect nobody using the default options.

To generate the proper embedded cusheet the following options were used:

```
    MKCUE=abcde.mkcue
    MKCUEOPTS=--wholedisk
    CUEREADERSYNTAX=abcde.mkcue
```