### PR TITLE
Add id3tag related info in abcde.conf

### DIFF
--- a/abcde.conf
+++ b/abcde.conf
@@ -187,6 +187,7 @@
 #ID3V2=id3v2
 #MID3V2=mid3v2
 #EYED3=eyeD3
+#ID3TAG=id3tag
 #CDPARANOIA=cdparanoia
 #CD_PARANOIA=cd-paranoia
 #CDDA2WAV=icedax
@@ -353,15 +354,17 @@
 #FFMPEGENCOPTS=
 
 # mp3 tagging:
-# There are three ways to tag MP3 files:
+# There are four ways to tag MP3 files:
 #   1. id3v1 (with id3)
 #   2. id3v2.3 (with id3v2)
 #   3. id3v2.4 (with eyeD3) This is the default
+#   4. id3tag (which may use id3v1 and/or id3v2 tags)
 # Use ID3TAGV to select one of the older formats:
 #ID3TAGV=id3v2.4
 #ID3OPTS=
 #ID3V2OPTS=
 #EYED3OPTS="--set-encoding=utf16-LE"
+#ID3TAGOPTS=
 
 # Other options:
 # The variable CDPARANOIOPTS is also used by GNU's cd-paranoia,


### PR DESCRIPTION
id3tag is a fourth method for tagging mp3, which was unmentioned in abcde.conf until now.