### PR TITLE
Add diskset tagging for eyeD3

### DIFF
--- a/abcde
+++ b/abcde
@@ -999,6 +999,13 @@ do_tag ()
 							${COMMENTOUTPUT:+--comment "$COMMENTOUTPUT"} \
 							);;
 					esac
+					if [ -n "$DISCNUMBER" ]; then
+					    addopts+=("-d $DISCNUMBER")
+					fi
+					if [ -n "$DISCTOTAL" ]; then
+					    addopts+=("-D $DISCTOTAL")
+					fi
+										
 					run_command "tagtrack-$OUTPUT-$1" nice $ENCNICE $TAGGER $TAGGEROPTS \
 						-A "$DALBUM" \
 						-a "$TRACKARTIST" -t "$TRACKNAME" \


### PR DESCRIPTION
Hiya!
Thanks for your work on abcde. I ran into your fork after noticing some bugs in my setup, and it really helped.

Since I'm using eyeD3, and have some multi-disc albums, I added handling of multi-disc sets to the eyeD3 tagger.
Simple enough. Hope you like it.

Didn't yet update any documentation, wanted to get your impressions first.