### PR TITLE
Don't pass the pager an empty string

### DIFF
--- a/abcde
+++ b/abcde
@@ -249,11 +249,11 @@ page ()
 		# Use the debian sensible-pager wrapper to pick the pager user
 		# has requested via their $PAGER environment variable
 		if [ -x "/usr/bin/sensible-pager" ]; then
-			/usr/bin/sensible-pager "$PAGEROPTS" "$PAGEFILE"
+			/usr/bin/sensible-pager ${PAGEROPTS:+"$PAGEROPTS"} "$PAGEFILE"
 		elif [ -x "$PAGER" ]; then
 			# That failed, try to load the preferred pager, starting
 			# with their PAGER variable
-			$PAGER "$PAGEROPTS" "$PAGEFILE"
+			$PAGER ${PAGEROPTS:+"$PAGEROPTS"} "$PAGEFILE"
 			# If that fails, check for less
 		elif [ -x /usr/bin/less ]; then
 			/usr/bin/less -f "$PAGEFILE"


### PR DESCRIPTION
There's an unexpected behaviour of less (the default pager) on Ubuntu and related Linuxes (I use Mint): 
when less is passed an empty parameter (""), it shows some environment variables, which is not useful.

(I found a short discussion [here](https://askubuntu.com/questions/1393543/why-does-less-accept-an-empty-filename-and-show-some-environment-variables)).

This change prevents abcde from calling the pager with an empty string when PAGEROPTS is defined but null (the default) or an empty string.
