### PR TITLE
musicbrainz-tool: Add multi-disc release support

### DIFF
--- a/abcde
+++ b/abcde
@@ -3111,6 +3111,16 @@ do_cddb_read ()
 	fi
 }
 
+do_multidisc() {
+    CDDBDATA="${ABCDETEMPDIR}/cddbread.$(checkstatus cddb-choice)"
+    MULTIDISC_INFO="${ABCDETEMPDIR}/multidisc.$(checkstatus cddb-choice)"
+    if [[ -e "$MULTIDISC_INFO" ]]; then
+        local disc_position disc_count
+        read -r disc_position disc_count < "$MULTIDISC_INFO"
+        sed -i "s/^DTITLE=.*/& Disc $disc_position of $disc_count/" "$CDDBDATA"
+    fi
+}
+
 # do_cddbedit
 do_cddbedit ()
 {
@@ -3255,6 +3265,10 @@ do_cddbedit ()
 	fi
 	CDDBDATA="${ABCDETEMPDIR}/cddbread.$(checkstatus cddb-choice)"
 	CDDBSOURCE=$(cat "${ABCDETEMPDIR}/datasource.$(checkstatus cddb-choice)")
+
+    # TODO make this conditional on a configuration option
+    do_multidisc
+
 	echo -n "Edit selected CDDB data " >&2
 	if [ "$INTERACTIVE" = "y" ]; then
 		if [ "$UNKNOWNDISK" = "y" ]; then
@@ -5525,6 +5539,8 @@ if [ "$DOCDDB" = "y" ]; then
 			fi
 		fi
 	fi
+
+
 	do_cddbedit
 
 	eval "$($CDDBTOOL parse "$CDDBDATA")"

--- a/abcde-musicbrainz-tool
+++ b/abcde-musicbrainz-tool
@@ -19,6 +19,7 @@ use MusicBrainz::DiscID;
 use WebService::MusicBrainz 1.0.4;
 use Getopt::Long;
 use Pod::Usage;
+use List::Util qw(max);
 
 my $FRAMES_PER_S = 75;
 
@@ -153,6 +154,8 @@ if ($command =~ m/^id/) {
 
 	    # Only consider the first medium
 	    my $medium = @mediums[0];
+            my $position = $medium->{'position'};
+            my $max_pos = (max (map { $_->{'position'} } @{$release->{'media'}}));
 	    my @tracks = @{ $medium->{'tracks'} };
 
 	    my $total_len = 0;
@@ -208,6 +211,12 @@ if ($command =~ m/^id/) {
 	    open (OUT, "> $workdir/asin.$releasenum");
 	    print OUT $release->{'asin'};
 	    close OUT;
+
+            if ($max_pos > 1) {
+                open (OUT, "> $workdir/multidisc.$releasenum");
+                print OUT $position . " " . $max_pos;
+                close OUT;
+            }
 
 	    # Check to see that this entry is unique; generate a checksum
 	    # and compare to any previous checksums


### PR DESCRIPTION
When ripping multiple-disc releases with abcde, I pretty much never want every single disc to go to the same folder, and *especially* don't want it when ripping to a single flac file (since each disc will get the exact same filename and overwrite the previous disc).

This changes makes it so that, only for multiple disc releases, "Disc X of Y" is appended to the disc title, which prevents all of the above issues.

Example discid to test on: 4IBC_jY.XzCRegIiMq.t6sXhzsQ-

This disc is part of 4 releases, two of which are multi-disc releases, so the results show all features of the change