### PR TITLE
prepended [Verbose] to vecho, and [Debug] to vvecho.

### DIFF
--- a/abcde
+++ b/abcde
@@ -1497,8 +1497,8 @@ do_encode ()
 						esac
 						;;
 					*)
-						vecho -n "DISTMP3:"
-						vecho "$DISTMP3 $DISTMP3OPTS $2 $IN $OUT >/dev/null 2>&1"
+						vecho -n "DISTMP3: "
+						vecho -c "$DISTMP3 $DISTMP3OPTS $2 $IN $OUT >/dev/null 2>&1"
 						$RUN_COMMAND nice $DISTMP3NICE $DISTMP3 $DISTMP3OPTS "$2" "$IN" "$OUT" > /dev/null 2>&1
 					;;
 				esac
@@ -2240,7 +2240,7 @@ do_discid ()
 {
 	SUBMITURL=
 	if [ -z "${CDDBDISCID}" ]; then
-		vecho -n "Getting CD track info... "
+		vecho "Getting CD track info... "
 		# In OSX, unmount the disc before a query
 		if [ "$OSFLAVOUR" = "OSX" ]; then
 			diskutil unmount "${CDROM#/dev/}"
@@ -3120,7 +3120,7 @@ do_cddb_read ()
 			;;
 		210|211)
 			# Multiple exact, (possibly multiple) inexact matches
-			vecho -n "Retrieving multiple matches... "
+			vecho "Retrieving multiple matches... "
 			grep -v '^[.]$' "${SOURCE_WORKDIR}/cddbquery" | (
 				# IN A SUB-SHELL - VARIABLES MODIFIED
 				# HERE DO NOT PERSIST IN THE PARENT
@@ -4069,46 +4069,52 @@ do_cdspeed ()
 	fi
 }
 
-# vecho [message]
+# vecho [-c|-n] [message]
 #
 # vecho outputs a message if EXTRAVERBOSE is 1 or more
+# -c is for a continuation line, -n is for no newline
 vecho ()
 {
 if [ x"$EXTRAVERBOSE" != "x" ] && [ "$EXTRAVERBOSE" -gt 0 ] ; then
 	case $1 in
 		warning) shift ; log warning "$@" ;;
-		*) >&4 echo "[Verbose] $@" ;;
+        -c) shift ; >&4 echo              "$@" ;; # for a continuation line
+		-n) shift ; >&4 echo -n "[Verbose] $@" ;;
+		*)          >&4 echo    "[Verbose] $@" ;;
 	esac
 fi
 }
 
-# vvecho [message]
+# vvecho [-c|-n] [message]
 #
 # vvecho outputs a message if EXTRAVERBOSE is 2 or more
+# -c is for a continuation line, -n is for no newline
 vvecho ()
 {
 if [ x"$EXTRAVERBOSE" != "x" ] && [ "$EXTRAVERBOSE" -gt 1 ] ; then
 	case $1 in
 		warning) shift ; log warning "$@" ;;
-		*) >&4 echo "[Debug] $@" ;;
+		-c) shift ; >&4 echo               "$@" ;; # for a continuation line
+		-n) shift ; >&4 echo -n "[Verbose2] $@" ;;
+		*)          >&4 echo    "[Verbose2] $@" ;;
 	esac
 fi
 }
 
-# decho [message] - removed in preference to vvecho.
+# decho [message]
 #
 # decho outputs a debug message if DEBUG is selected
-#decho ()
-#{
-#if [ x"$DEBUG" != "x" ]; then
-#	if echo "$1" | grep "^\[" > /dev/null 2>&1 ; then
-#		DEBUGECHO=$(echo "$@" | tr -d '[]')
-#		echo >&4 "[DEBUG] $DEBUGECHO: $(eval echo \\$${DEBUGECHO})"
-#	else
-#		echo >&4 "[DEBUG] $1"
-#	fi
-#fi
-#}
+decho ()
+{
+if [ x"$DEBUG" != "x" ]; then
+	if echo "$1" | grep "^\[" > /dev/null 2>&1 ; then
+		DEBUGECHO=$(echo "$@" | tr -d '[]')
+		echo >&4 "[DEBUG] $DEBUGECHO: $(eval echo \\$${DEBUGECHO})"
+	else
+		echo >&4 "[DEBUG] $1"
+	fi
+fi
+}
 
 # User-redefinable functions
 # Custom filename munging:
@@ -4631,7 +4637,7 @@ while getopts 1a:bBc:C:d:DefgGhj:klLmMnNo:pPQ:r:s:S:t:T:UvVxX:w:W:z opt ; do
 		   STARTTRACKNUMBERTAG="y"
 		   vecho Comment is "${COMMENT}" >&2
 		   ;;
-		z) CDROMREADERSYNTAX=debug ; EJECTCD="n" ;;
+		z) DEBUG=y ; CDROMREADERSYNTAX=debug ; EJECTCD="n" ;;
 		?) usage; exit ;;
 	esac
 done
@@ -5422,20 +5428,14 @@ if [ "$USEPIPES" = "y" ]; then
 		aac)
 			PIPEENCODERSVARCHECK="PIPE_$AACENCODERSYNTAX" ;;
 	esac
-	# decho "PIPERIPPERSVARCHECK: $( eval echo "\$$PIPERIPPERSVARCHECK" )"
-	if CDROMREADERSYNTAX=debug; then
-		echo "[DEBUG] PIPERIPPERSVARCHECK: $( eval echo "\$$PIPERIPPERSVARCHECK" )"
-	fi
+	decho "PIPERIPPERSVARCHECK: $( eval echo "\$$PIPERIPPERSVARCHECK" )"
 	if [ "$( eval echo "\$$PIPERIPPERSVARCHECK" )" = "$" ] || \
 	   [ "$( eval echo "\$$PIPERIPPERSVARCHECK" )" = "" ] ; then
 		log error "no support for pipes with given ripper"
 		log error "read the FAQ file from the source tarball to get help."
 		exit 1;
 	fi
-	# decho "PIPEENCODERSVARCHECK: $( eval echo "\$$PIPEENCODERSVARCHECK" )"
-	if CDROMREADERSYNTAX=debug; then
-		echo "[DEBUG] PIPEENCODERSVARCHECK: $( eval echo "\$$PIPEENCODERSVARCHECK" )"
-	fi
+	decho "PIPEENCODERSVARCHECK: $( eval echo "\$$PIPEENCODERSVARCHECK" )"
 	if [ "$( eval echo "\$$PIPEENCODERSVARCHECK" )" = "$" ] || \
 	   [ "$( eval echo "\$$PIPEENCODERSVARCHECK" )" = "" ] ; then
 		log error "no support for pipes with given encoder"
@@ -5525,7 +5525,7 @@ if [ "$DOREAD" = "y" ]; then
 	# User-definable function to set some things. Use it for
 	#  - closing the CD tray with eject -t
 	#  - set the CD speed value with eject -x
-	vecho -n "Executing customizable pre-read function... "
+	vecho "Executing customizable pre-read function... "
 
 	pre_read # Execute the user-defined pre-read function. Close the CD with it.
 

--- a/abcde
+++ b/abcde
@@ -4077,7 +4077,7 @@ vecho ()
 if [ x"$EXTRAVERBOSE" != "x" ] && [ "$EXTRAVERBOSE" -gt 0 ] ; then
 	case $1 in
 		warning) shift ; log warning "$@" ;;
-		*) >&4 echo "$@" ;;
+		*) >&4 echo "[Verbose] $@" ;;
 	esac
 fi
 }
@@ -4090,25 +4090,25 @@ vvecho ()
 if [ x"$EXTRAVERBOSE" != "x" ] && [ "$EXTRAVERBOSE" -gt 1 ] ; then
 	case $1 in
 		warning) shift ; log warning "$@" ;;
-		*) >&4 echo "$@" ;;
+		*) >&4 echo "[Debug] $@" ;;
 	esac
 fi
 }
 
-# decho [message]
+# decho [message] - removed in preference to vvecho.
 #
 # decho outputs a debug message if DEBUG is selected
-decho ()
-{
-if [ x"$DEBUG" != "x" ]; then
-	if echo "$1" | grep "^\[" > /dev/null 2>&1 ; then
-		DEBUGECHO=$(echo "$@" | tr -d '[]')
-		echo >&4 "[DEBUG] $DEBUGECHO: $(eval echo \\$${DEBUGECHO})"
-	else
-		echo >&4 "[DEBUG] $1"
-	fi
-fi
-}
+#decho ()
+#{
+#if [ x"$DEBUG" != "x" ]; then
+#	if echo "$1" | grep "^\[" > /dev/null 2>&1 ; then
+#		DEBUGECHO=$(echo "$@" | tr -d '[]')
+#		echo >&4 "[DEBUG] $DEBUGECHO: $(eval echo \\$${DEBUGECHO})"
+#	else
+#		echo >&4 "[DEBUG] $1"
+#	fi
+#fi
+#}
 
 # User-redefinable functions
 # Custom filename munging:
@@ -4631,7 +4631,7 @@ while getopts 1a:bBc:C:d:DefgGhj:klLmMnNo:pPQ:r:s:S:t:T:UvVxX:w:W:z opt ; do
 		   STARTTRACKNUMBERTAG="y"
 		   vecho Comment is "${COMMENT}" >&2
 		   ;;
-		z) DEBUG=y ; CDROMREADERSYNTAX=debug ; EJECTCD="n" ;;
+		z) CDROMREADERSYNTAX=debug ; EJECTCD="n" ;;
 		?) usage; exit ;;
 	esac
 done
@@ -5422,14 +5422,20 @@ if [ "$USEPIPES" = "y" ]; then
 		aac)
 			PIPEENCODERSVARCHECK="PIPE_$AACENCODERSYNTAX" ;;
 	esac
-	decho "PIPERIPPERSVARCHECK: $( eval echo "\$$PIPERIPPERSVARCHECK" )"
+	# decho "PIPERIPPERSVARCHECK: $( eval echo "\$$PIPERIPPERSVARCHECK" )"
+	if CDROMREADERSYNTAX=debug; then
+		echo "[DEBUG] PIPERIPPERSVARCHECK: $( eval echo "\$$PIPERIPPERSVARCHECK" )"
+	fi
 	if [ "$( eval echo "\$$PIPERIPPERSVARCHECK" )" = "$" ] || \
 	   [ "$( eval echo "\$$PIPERIPPERSVARCHECK" )" = "" ] ; then
 		log error "no support for pipes with given ripper"
 		log error "read the FAQ file from the source tarball to get help."
 		exit 1;
 	fi
-	decho "PIPEENCODERSVARCHECK: $( eval echo "\$$PIPEENCODERSVARCHECK" )"
+	# decho "PIPEENCODERSVARCHECK: $( eval echo "\$$PIPEENCODERSVARCHECK" )"
+	if CDROMREADERSYNTAX=debug; then
+		echo "[DEBUG] PIPEENCODERSVARCHECK: $( eval echo "\$$PIPEENCODERSVARCHECK" )"
+	fi
 	if [ "$( eval echo "\$$PIPEENCODERSVARCHECK" )" = "$" ] || \
 	   [ "$( eval echo "\$$PIPEENCODERSVARCHECK" )" = "" ] ; then
 		log error "no support for pipes with given encoder"

--- a/test-snippets/README
+++ b/test-snippets/README
@@ -1,0 +1,6 @@
+Directory for test code snippets
+
+Allows for testing individual functions, 
+without having to fully invoke abcde.
+
+Not needed/wanted as part of deployment.

--- a/test-snippets/log-testing.sh
+++ b/test-snippets/log-testing.sh
@@ -1,4 +1,4 @@
-#! /opt/homebrew/bin/bash
+#! /bin/bash
 
 # log [level] [message]
 #

--- a/test-snippets/log-testing.sh
+++ b/test-snippets/log-testing.sh
@@ -1,0 +1,64 @@
+#! /opt/homebrew/bin/bash
+
+# log [level] [message]
+#
+# log outputs the right message in a common format
+log ()
+{
+	BLURB="$1"
+	shift
+	case $BLURB in
+		error)   >&2 echo "[ERROR] abcde: $@" >&2 ;;
+		warning) >&2 echo "[WARNING] $@" >&2 ;;
+		info)    >&4 echo "[INFO] $@" ;;
+        console) >&4 echo "$@" ;;
+	esac
+}
+
+# vecho [-c|-n] [message]
+#
+# vecho outputs a message if EXTRAVERBOSE is 1 or more
+# -c is for a continuation line, -n is for no newline
+vecho ()
+{
+if [ x"$EXTRAVERBOSE" != "x" ] && [ "$EXTRAVERBOSE" -gt 0 ] ; then
+	case $1 in
+		warning) shift ; log warning "$@" ;;
+        -c) shift ; >&4 echo              "$@" ;; # for a continuation line
+		-n) shift ; >&4 echo -n "[Verbose] $@" ;;
+		*)          >&4 echo    "[Verbose] $@" ;;
+	esac
+fi
+}
+
+# vvecho [-c|-n] [message]
+#
+# vvecho outputs a message if EXTRAVERBOSE is 2 or more
+# -c is for a continuation line, -n is for no newline
+vvecho ()
+{
+if [ x"$EXTRAVERBOSE" != "x" ] && [ "$EXTRAVERBOSE" -gt 1 ] ; then
+	case $1 in
+		warning) shift ; log warning "$@" ;;
+		-c) shift ; >&4 echo               "$@" ;; # for a continuation line
+		-n) shift ; >&4 echo -n "[Verbose2] $@" ;;
+		*)          >&4 echo    "[Verbose2] $@" ;;
+	esac
+fi
+}
+
+exec 4>&1
+EXTRAVERBOSE=$1
+
+echo "testing vecho and vvecho functions"
+log console "call with a number 1 or 2 to see verbose logging output"
+vecho "with newline"
+vecho -n "without newline: "
+vecho -c "continued on the same line"
+
+vvecho "with newline"
+vvecho -n "without newline: "
+vvecho -c "continued on the same line"
+
+log console "testing console log -- print without prefix"
+log info "testing info log -- print with [INFO] prefix"


### PR DESCRIPTION
added the prepended level information to help make better sense of the console output.

Simplified logic used to debug a single special case, and removed decho

This is the first pass to deal with issues 1 and 2 as described in #45.

decho was only used for one very niche debug case:
when setting the command line option -z to enable CDROMREADERSYNTAX=debug
simplified the logic and eliminated (commented out) the unneeded decho() function.
Not a complete solution as it does an `echo [DEBUG]`, but that can later be turned into `log debug` if/when the log function is expanded to handle that case. -- a POSSIBLE way of handling the output in a more controlled fashion... but that might also need a local override of the EXTRAVERBOSE variable to ensure the output.

I _think_ this might be a reasonable first pass.